### PR TITLE
Parameterize name of world and pause simulation by default

### DIFF
--- a/launch/keyboard.launch
+++ b/launch/keyboard.launch
@@ -2,11 +2,12 @@
 <launch>
     <!-- Start Webots -->
     <arg name="no-gui" default="false" doc="Start Webots with minimal GUI"/>
+    <arg name="world" default="square" doc="The name of the webots world to launch" />
     <include file="$(find simulation)/launch/webots.launch">
-        <arg name="mode" value="realtime"/>
+        <arg name="mode" value="pause"/>
         <arg name="no-gui" value="$(arg no-gui)"/>
         <!-- modify with path to world-->
-        <arg name="world" value="$(find simulation)/worlds/world.wbt"/>
+        <arg name="world" value="$(find simulation)/worlds/$(arg world).wbt"/>
     </include>
 
     <arg name="controller_type" default="0"/>

--- a/launch/simulation.launch
+++ b/launch/simulation.launch
@@ -2,11 +2,12 @@
 <launch>
     <!-- Start Webots -->
     <arg name="no-gui" default="false" doc="Start Webots with minimal GUI"/>
+    <arg name="world" default="square" doc="The name of the webots world to launch" />
     <include file="$(find simulation)/launch/webots.launch">
-        <arg name="mode" value="realtime"/>
+        <arg name="mode" value="pause"/>
         <arg name="no-gui" value="$(arg no-gui)"/>
         <!-- modify with path to world-->
-        <arg name="world" value="$(find simulation)/worlds/world.wbt"/>
+        <arg name="world" value="$(find simulation)/worlds/$(arg world).wbt"/>
     </include>
 
     <!-- External Webots Robot Controller -->


### PR DESCRIPTION
This PR updates the `keyboard.launch` and `simulation.launch` to accept as an argument, the name of the world file to launch in Webots. It also pauses the simulation by default to allow for all ROS nodes to initialize before starting the simulation.

As an example, to launch the `straight_line.wbt` world, which is not the default (the default is set to "square") run the following in the terminal:
```bash
roslaunch launch/simulation.launch world:=straight_line
```

Notice that we don't include the extension as the launch file handles this automatically.