### PR TITLE
Update CI to run on PR and main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: Continuous Integration
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   catkin_lint:


### PR DESCRIPTION
This small change runs CI on every PR and on the main branch, rather than just for PRs.