### PR TITLE
Send GPS data to Portal

### DIFF
--- a/src/portal_connection/scripts/portal.py
+++ b/src/portal_connection/scripts/portal.py
@@ -62,6 +62,7 @@ class PortalConnection():
     def gps_callback(self, msg):
         self.state["gps"] = {"lat": msg.latitude, "lng": msg.longitude}
 
+
 if __name__ == '__main__':
     try:
         _ = PortalConnection()

--- a/src/portal_connection/scripts/portal.py
+++ b/src/portal_connection/scripts/portal.py
@@ -2,6 +2,7 @@
 
 import rospy
 import socketio
+from sensor_msgs.msg import NavSatFix
 
 
 class PortalConnection():
@@ -21,7 +22,7 @@ class PortalConnection():
         self.secret = rospy.get_param("~secret")
 
         # Define subscribers
-        # TODO(angus)
+        rospy.Subscriber("/gps/filtered", NavSatFix, self.gps_callback)
 
         # Use timer to periodically publish state of this class
         rospy.Timer(rospy.Duration(1 / self.frequency), self.emit_state)
@@ -58,6 +59,8 @@ class PortalConnection():
             except socketio.exceptions.BadNamespaceError:
                 rospy.logwarn("Failed to send data to Portal...will retry in a bit")
 
+    def gps_callback(self, msg):
+        self.state["gps"] = {"lat": msg.latitude, "lng": msg.longitude}
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
This PR sends the filtered GPS data from [`navsat_transform_node`](https://docs.ros.org/en/noetic/api/robot_localization/html/navsat_transform_node.html) in our localization stack to the Portal.

**This requires the changes in #26 to be merged first.**

Other data such as battery or state cannot be sent yet as they have not been implemented yet. This will be added in a future PR. However, adding this functionality sooner may allow us to do some integration testing between the Portal and our autonomous system.